### PR TITLE
fix: tracing headers parameters not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ npm run lint-fix # format source files
 | [#229][#229]   | [SHOULD consider to design `POST` and `PATCH` idempotent][#229]                                      | - | - | - |
 | [#230][#230]   | [MAY consider to support `Idempotency-Key` header][#230]                                             | - | - | - |
 | [#231][#231]   | [Should use secondary key for idempotent `POST` design][#231]                                        | - | - | - |
-| [#233a][#233a] | [MUST request must use b3 tracing headers][#233a]                                                    | - | :heavy_check_mark: | - |
+| [#233a][#233a] | [MUST request must provide b3 tracing headers][#233a]                                                | - | :heavy_check_mark: | - |
 | [#234][#234]   | [MUST only use durable and immutable remote references][#234]                                        | - | - | - |
 | [#235][#235]   | [SHOULD name date/time properties with `_at` suffix][#235]                                           | - | - | - |
 | [#236][#236]   | [SHOULD design simple query languages using query parameters][#236]                                  | - | - | - |

--- a/baloise.yml
+++ b/baloise.yml
@@ -98,14 +98,14 @@ rules:
           - '511'
           - default
 
-  # MUST use b3 tracing [233a]
+  # MUST request must provide b3 tracing [233a]
   # => Alternative to https://opensource.zalando.com/restful-api-guidelines/#233
 
   must-use-b3-tracing:
     message: B3 header X-B3-Traceid or X-B3-Spanid missing
     description: MUST use b3 tracing [233a]
     documentationUrl: https://github.com/baloise-incubator/spectral-ruleset/blob/main/doc/rules/requests-must-use-b3-tracing.md
-    severity: warn
+    severity: error
     given: $.paths.*.*.parameters
     then:
       function: validate-b3-tracing

--- a/doc/rules/requests-must-use-b3-tracing.md
+++ b/doc/rules/requests-must-use-b3-tracing.md
@@ -1,5 +1,5 @@
-# MUST request must use b3 tracing headers
-The following header parameter are mandatory for any request:
+# MUST request must provide b3 tracing headers
+The following header parameter must be provided for any request:
 
 - `X-B3-Traceid`
 - `X-B3-Spanid`

--- a/functions/validate-b3-tracing.js
+++ b/functions/validate-b3-tracing.js
@@ -14,7 +14,7 @@ module.exports = (targetValue) => {
       param.name && (param.name.toLowerCase() === 'x-b3-traceid' || param.name.toLowerCase() === 'x-b3-spanid'),
   );
 
-  if (b3Params.length !== 2 || !b3Params.every((param) => param.in === 'header' && param.required === true)) {
+  if (b3Params.length !== 2 || !b3Params.every((param) => param.in === 'header')) {
     return [
       {
         message: `B3 header X-B3-Traceid or X-B3-Spanid missing`,

--- a/tests/233a-MUST-request-must-provide-b3-tracing.test.ts
+++ b/tests/233a-MUST-request-must-provide-b3-tracing.test.ts
@@ -1,7 +1,7 @@
 import { DiagnosticSeverity } from '@stoplight/types';
 import { loadOpenApiSpec, lint } from './helpers';
 
-describe('MUST use b3 tracing [233a]', () => {
+describe('MUST request must provide b3 tracing [233a]', () => {
   test('Assert missing X-B3-Traceid', async () => {
     const openApi = await loadOpenApiSpec('base-openapi.yml');
     openApi.paths['/example'].get.parameters = openApi.paths['/example'].get.parameters.filter(
@@ -13,7 +13,7 @@ describe('MUST use b3 tracing [233a]', () => {
       expect.objectContaining({
         code: 'must-use-b3-tracing',
         message: 'B3 header X-B3-Traceid or X-B3-Spanid missing',
-        severity: DiagnosticSeverity.Warning,
+        severity: DiagnosticSeverity.Error,
       }),
     ]);
   });
@@ -29,7 +29,7 @@ describe('MUST use b3 tracing [233a]', () => {
       expect.objectContaining({
         code: 'must-use-b3-tracing',
         message: 'B3 header X-B3-Traceid or X-B3-Spanid missing',
-        severity: DiagnosticSeverity.Warning,
+        severity: DiagnosticSeverity.Error,
       }),
     ]);
   });

--- a/tests/fixtures/base-openapi.yml
+++ b/tests/fixtures/base-openapi.yml
@@ -115,7 +115,7 @@ components:
     HeaderB3Spanid:
       in: header
       name: X-B3-Spanid
-      required: true
+      required: false
       schema:
         type: string
   schemas:


### PR DESCRIPTION
parameter must be available on interface but should be required

Requested by @ArthurNeudeck 

**Info:**
I think there was a small miss understanding. Every service provider should provide the ability to pass tracing information but it's not mandatory to do so for every consumer of the service (e.g. external partners). If no information passed the service provider has to create the tracing context. Additionally severity raised to error as in Baloise liniting errors aren't breaking.