### PR TITLE
removed function/debug from zalando.yml

### DIFF
--- a/zalando.yml
+++ b/zalando.yml
@@ -7,7 +7,6 @@ functions:
   - count-resource-types
   - is-object-schema
   - is-problem-json-schema
-  - debug
 
 rules:
   # https://meta.stoplight.io/docs/spectral/docs/reference/openapi-rules.md#oas3-schema


### PR DESCRIPTION
As described in the [issue](https://github.com/baloise-incubator/spectral-ruleset/issues/28) I have removed the not used debug function from the zalando specification