### PR TITLE
feat: Add 422 as well understood for baloise

### DIFF
--- a/baloise.yml
+++ b/baloise.yml
@@ -2,6 +2,7 @@ extends: [./zalando.yml] # We're extending the zalando ruleset by replacing or a
 
 functions:
   - validate-b3-tracing
+  - assert-http-codes-for-operation
 
 rules:
   # CAN use URI versioning [115a]
@@ -98,6 +99,56 @@ rules:
           - '511'
           - default
 
+  should-use-well-understood-http-status-codes: off
+
+  should-use-additional-well-understood-http-status-codes:
+    message: '{{error}}'
+    description: MUST use standard HTTP status codes [150]
+    documentationUrl: https://github.com/baloise-incubator/spectral-ruleset/blob/main/doc/rules/should-use-additional-well-understood-http-status-codes.md
+    severity: warn
+    given: $.paths.*
+    then:
+      function: assert-http-codes-for-operation
+      functionOptions:
+        wellUnderstood:
+          # Success Codes
+          '200': [ ALL ]
+          '201': [ POST, PUT ]
+          '202': [ POST, PUT, DELETE, PATCH ]
+          '204': [ PUT, DELETE, PATCH ]
+          '207': [ POST ]
+
+          # Redirection Codes
+          '301': [ ALL ]
+          '303': [ PATCH, POST, PUT, DELETE ]
+          '304': [ GET, HEAD ]
+
+          # Client Side Error Codes
+          '400': [ ALL ]
+          '401': [ ALL ]
+          '403': [ ALL ]
+          '404': [ ALL ]
+          '405': [ ALL ]
+          '406': [ ALL ]
+          '408': [ ALL ]
+          '409': [ POST, PUT, DELETE, PATCH ]
+          '410': [ ALL ]
+          '412': [ PUT, DELETE, PATCH ]
+          '415': [ POST, PUT, DELETE, PATCH ]
+          '422': [ ALL ]
+          '423': [ PUT, DELETE, PATCH ]
+          '428': [ ALL ]
+          '429': [ ALL ]
+
+          # Server Side Error Codes
+          '500': [ ALL ]
+          '501': [ ALL ]
+          '503': [ ALL ]
+
+          # OpenApi
+          'default': [ ALL ]
+
+
   # MUST request must provide b3 tracing [233a]
   # => Alternative to https://opensource.zalando.com/restful-api-guidelines/#233
 
@@ -146,3 +197,5 @@ rules:
       function: pattern
       functionOptions:
         match: ^[a-z]+((\d)|([A-Z0-9][a-z0-9]+))*([A-Z])?$
+
+

--- a/doc/rules/should-use-additional-well-understood-http-status-codes.md
+++ b/doc/rules/should-use-additional-well-understood-http-status-codes.md
@@ -1,0 +1,3 @@
+# SHOULD use additional well understood http status codes [150a]
+
+We will also add 422 status code to well understood http status codes for all methods defined by [zalando](https://opensource.zalando.com/restful-api-guidelines/#150).

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@baloise/spectral-rules",
-      "version": "0.7.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@stoplight/spectral-cli": "^6.3.0",

--- a/tests/150a-MUST-use-additional-standard-HTTP-status-codes.test.ts
+++ b/tests/150a-MUST-use-additional-standard-HTTP-status-codes.test.ts
@@ -86,6 +86,7 @@ const WELL_UNDERSTOOD = {
   '410': ['ALL'],
   '412': ['PUT', 'DELETE', 'PATCH'],
   '415': ['POST', 'PUT', 'DELETE', 'PATCH'],
+  '422': ['ALL'],
   '423': ['PUT', 'DELETE', 'PATCH'],
   '428': ['ALL'],
   '429': ['ALL'],
@@ -153,12 +154,12 @@ describe('MUST use additional standard HTTP status codes [150a]', () => {
       }),
       {},
     );
-    const result = await lint(openApi);
+    const result = await lint(openApi, 'baloise');
     STANDARD_BUT_NOT_WELL_UNDERSTOOD_CODES.forEach((code) => {
       expect(result).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            code: 'should-use-well-understood-http-status-codes',
+            code: 'should-use-additional-well-understood-http-status-codes',
             message: `${code} is not a well-understood HTTP status code`,
             severity: DiagnosticSeverity.Warning,
           }),
@@ -169,7 +170,7 @@ describe('MUST use additional standard HTTP status codes [150a]', () => {
       expect(result).not.toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            code: 'should-use-well-understood-http-status-codes',
+            code: 'should-use-additional-well-understood-http-status-codes',
             message: `${code} is not a well-understood HTTP status code`,
             severity: DiagnosticSeverity.Warning,
           }),
@@ -196,16 +197,16 @@ describe('MUST use additional standard HTTP status codes [150a]', () => {
         },
       },
     };
-    const result = await lint(openApi);
+    const result = await lint(openApi, 'baloise');
     expect(result).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          code: 'should-use-well-understood-http-status-codes',
+          code: 'should-use-additional-well-understood-http-status-codes',
           message: `201 is not a well-understood HTTP status code for GET`,
           severity: DiagnosticSeverity.Warning,
         }),
         expect.objectContaining({
-          code: 'should-use-well-understood-http-status-codes',
+          code: 'should-use-additional-well-understood-http-status-codes',
           message: `204 is not a well-understood HTTP status code for POST`,
           severity: DiagnosticSeverity.Warning,
         }),


### PR DESCRIPTION
Add http status code 422 to well understood status codes. Allow 422 for all methods.