### PR TITLE
fix: use lookahead to avoid catastrophic backtracking

### DIFF
--- a/zalando.yml
+++ b/zalando.yml
@@ -92,7 +92,7 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: ^(([\/a-z][a-z0-9\-\/]*)?({[^}]*})?)+$
+        match: ^(?=((([\/a-z][a-z0-9\-\/]*)?({[^}]*})?)+))\1$
 
   # MUST use snake_case (never camelCase) for query parameters [130]
   # => https://opensource.zalando.com/restful-api-guidelines/#130


### PR DESCRIPTION
Fixes https://github.com/baloise-incubator/spectral-ruleset/issues/32